### PR TITLE
Feature/refactor random taco to use taco component

### DIFF
--- a/src/RandomTaco.css
+++ b/src/RandomTaco.css
@@ -31,6 +31,7 @@
 }
 
 .ingredient-container {
+  width: 100%;
   display: flex;
   justify-content: space-between;
 }

--- a/src/RandomTaco.css
+++ b/src/RandomTaco.css
@@ -6,48 +6,13 @@
   background-color: #F5DBB4;
 }
 
-.total-recipe-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  overflow-y: scroll;
-  border: solid black .4rem;
-  height: 70%;
-  width: 70%;
-  margin: 1rem;
-}
-
-.title-and-recipe-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 80%;
-}
-
 .button-container {
   display: flex;
   justify-content: space-between;
   width: 50%;
 }
 
-.ingredient-container {
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-}
 
-.ingredient-recipe {
-  width: 70%;
-  font-size: 1rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-
-.ingredient-name {
-  width: 30%;
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
 
 .random-taco,
 .save-taco {

--- a/src/RandomTaco.js
+++ b/src/RandomTaco.js
@@ -41,7 +41,7 @@ class RandomTaco extends React.Component {
   .then(response => response.json())
   .then(data => this.setState({
     currentTaco: data,
-    currentTacoName: data.name ? data.name : null,
+    currentTacoName: data.name,
     currentBaseLayerName: data.base_layer.name ? this.capitalizeFirstLetter(data.base_layer.name) : null,
     currentBaseLayerRecipe: data.base_layer.recipe ? data.base_layer.recipe.replace(/[^.,\sa-zA-Z]/g, '') : null,
     currentShellName: data.shell ? this.capitalizeFirstLetter(data.shell.name) : null,
@@ -59,7 +59,7 @@ class RandomTaco extends React.Component {
   .then(response => response.json())
   .then(data => this.setState({
     currentTaco: data,
-    currentTacoName: null,
+    currentTacoName: "Randomly Generated Taco",
     currentBaseLayerName: this.capitalizeFirstLetter(data.base_layer.name),
     currentBaseLayerRecipe: data.base_layer.recipe.replace(/[^.,\sa-zA-Z]/g, ''),
     currentShellName: this.capitalizeFirstLetter(data.shell.name),

--- a/src/RandomTaco.js
+++ b/src/RandomTaco.js
@@ -2,6 +2,7 @@ import React from 'react';
 // import HomePage from './HomePage'
 import './RandomTaco.css'
 import { Link } from 'react-router-dom';
+import Taco from './Taco'
 // import { getRandomCuratedTaco, getRandomWackyTaco } from './fetchRequests';
 
 class RandomTaco extends React.Component {
@@ -81,37 +82,21 @@ class RandomTaco extends React.Component {
   render() {
     return (
       <main className="random-taco-main">
-        <div className="total-recipe-container">
-          {this.state.currentTacoName &&
-          <div className="title-and-recipe-container">
-            <h2 className="curated-title">{this.state.currentTacoName}</h2>
-          </div>}
-          {this.state.currentBaseLayerName &&
-          <div className="ingredient-container">
-            <h3 className="ingredient-name">{this.state.currentBaseLayerName}:</h3>
-            <p className="ingredient-recipe">{this.state.currentBaseLayerRecipe.replace(`${this.state.currentBaseLayerName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}`, "")}</p>
-          </div>}
-          {this.state.currentShellName &&
-          <div className="ingredient-container">
-            <h3 className="ingredient-name">{this.state.currentShellName}:</h3>
-            <p className="ingredient-recipe">{this.state.currentShellRecipe.replace(`${this.state.currentShellName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}</p>
-          </div>}
-          {this.state.currentMixinName &&
-          <div className="ingredient-container">
-            <h3 className="ingredient-name">{this.state.currentMixinName}:</h3>
-            <p className="ingredient-recipe">{this.state.currentMixinRecipe.replace(`${this.state.currentMixinName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}</p>
-          </div>}
-          {this.state.currentCondimentName &&
-          <div className="ingredient-container">
-            <h3 className="ingredient-name">{this.state.currentCondimentName}:</h3>
-            <p className="ingredient-recipe">{this.state.currentCondimentRecipe.replace(`${this.state.currentCondimentName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}</p>
-          </div>}
-          {this.state.currentSeasoningName &&
-          <div className="ingredient-container">
-            <h3 className="ingredient-name">{this.state.currentSeasoningName}:</h3>
-            <p className="ingredient-recipe">{this.state.currentSeasoningRecipe.replace(`${this.state.currentSeasoningName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}</p>
-          </div>}
-        </div>
+        {this.state.currentTaco &&
+        <Taco
+        name={this.state.currentTacoName}
+        baseLayerName={this.state.currentBaseLayerName}
+        baseLayerRecipe={this.state.currentBaseLayerRecipe}
+        shellName={this.state.currentShellName}
+        shellRecipe={this.state.currentShellRecipe}
+        mixinName={this.state.currentMixinName}
+        mixinRecipe={this.state.currentMixinRecipe}
+        condimentName={this.state.currentCondimentName}
+        condimentRecipe={this.state.currentCondimentRecipe}
+        seasoningName={this.state.currentSeasoningName}
+        seasoningRecipe={this.state.currentSeasoningRecipe}
+         />
+          }
         <div className="button-container">
           <Link to="/">
             <button className="back-to-home">Back to Home</button>

--- a/src/RandomTaco.js
+++ b/src/RandomTaco.js
@@ -32,6 +32,7 @@ class RandomTaco extends React.Component {
   }
 
   addTacoToSavedTacos = () => {
+    this.state.currentTaco.id = this.state.savedTacos.length + 1
     this.state.savedTacos.push(this.state.currentTaco)
     console.log(this.state.savedTacos)
   }

--- a/src/RandomTaco.js
+++ b/src/RandomTaco.js
@@ -84,6 +84,7 @@ class RandomTaco extends React.Component {
       <main className="random-taco-main">
         {this.state.currentTaco &&
         <Taco
+        id={this.state.savedTacos.length + 1}
         name={this.state.currentTacoName}
         baseLayerName={this.state.currentBaseLayerName}
         baseLayerRecipe={this.state.currentBaseLayerRecipe}

--- a/src/RandomTaco.js
+++ b/src/RandomTaco.js
@@ -32,8 +32,9 @@ class RandomTaco extends React.Component {
   }
 
   addTacoToSavedTacos = () => {
-    this.state.currentTaco.id = this.state.savedTacos.length + 1
-    this.state.savedTacos.push(this.state.currentTaco)
+    const tacoToBeSaved = this.state.currentTaco
+    tacoToBeSaved.id = this.state.savedTacos.length + 1
+    this.state.savedTacos.push(tacoToBeSaved)
     console.log(this.state.savedTacos)
   }
 

--- a/src/Taco.css
+++ b/src/Taco.css
@@ -1,0 +1,36 @@
+.total-recipe-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-y: scroll;
+  border: solid black .4rem;
+  height: 70%;
+  width: 70%;
+  margin: 1rem;
+}
+
+.title-and-recipe-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 80%;
+}
+
+.ingredient-container {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}
+
+.ingredient-recipe {
+  width: 70%;
+  font-size: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.ingredient-name {
+  width: 30%;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}

--- a/src/Taco.js
+++ b/src/Taco.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import './Taco.css'
+
+const Taco = ({name, baseLayerName, baseLayerRecipe, shellName, shellRecipe, mixinName, mixinRecipe, condimentName, condimentRecipe, seasoningName, seasoningRecipe}) => {
+  return (
+    <div className="total-recipe-container">
+      {name &&
+      <div className="title-and-recipe-container">
+        <h2 className="curated-title">{name}</h2>
+      </div>}
+      {baseLayerName &&
+      <div className="ingredient-container">
+        <h3 className="ingredient-name">{baseLayerName}:</h3>
+        <p className="ingredient-recipe">{baseLayerRecipe.replace(`${baseLayerName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}</p>
+      </div>}
+      {shellName &&
+      <div className="ingredient-container">
+        <h3 className="ingredient-name">{shellName}:</h3>
+        <p className="ingredient-recipe">{shellRecipe.replace(`${shellName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}</p>
+      </div>}
+      {mixinName &&
+      <div className="ingredient-container">
+        <h3 className="ingredient-name">{mixinName}:</h3>
+        <p className="ingredient-recipe">{mixinRecipe.replace(`${mixinName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}</p>
+      </div>}
+      {condimentName &&
+      <div className="ingredient-container">
+        <h3 className="ingredient-name">{condimentName}:</h3>
+        <p className="ingredient-recipe">{condimentRecipe.replace(`${condimentName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}</p>
+      </div>}
+      {seasoningName &&
+      <div className="ingredient-container">
+        <h3 className="ingredient-name">{seasoningName}:</h3>
+        <p className="ingredient-recipe">{seasoningRecipe.replace(`${seasoningName.replace(/[^.,\sa-zA-Z]/g, '')}`, "")}</p>
+      </div>}
+    </div>
+  )
+}
+
+
+
+export default Taco


### PR DESCRIPTION
### What does this PR do?
- This PR completes the refactor, moving code that previously rendered a random taco in the RandomTaco component to a reusable Taco component, passing state from RandomTaco to Taco as props.

### What does it fix?
- No bugs to fix at this point.

### Is this a feature or a fix?
- This is a feature, making Taco a reusable component and importing it into the RandomTaco component to be rendered. Taco can now be used when a saved taco thumbnail is clicked on in the saved taco section to display the full recipe details.

### Where should the reviewer start?
- N/A since the same functionality is present, this was just a refactor.

### How should this be tested?
- N/A
